### PR TITLE
Update dataset import from fetch_mldata to fetch_openml

### DIFF
--- a/tutorials/tutorial_pca.ipynb
+++ b/tutorials/tutorial_pca.ipynb
@@ -40,7 +40,7 @@
     "import matplotlib.pyplot as plt\n",
     "plt.style.use('fivethirtyeight')\n",
     "from ipywidgets import interact\n",
-    "from sklearn.datasets import fetch_mldata"
+    "from sklearn.datasets import fetch_openml()"
    ]
   },
   {


### PR DESCRIPTION
fetch_mldata throws an ImportError. "fetch_mldata() is dead because it relied on a website that died.." see https://github.com/ageron/handson-ml/issues/529