### PR TITLE
Fix transpose order in prior marginal variance formula in tutorial_linear_regression.ipynb

### DIFF
--- a/tutorials/tutorial_linear_regression.ipynb
+++ b/tutorials/tutorial_linear_regression.ipynb
@@ -1031,7 +1031,7 @@
     "$$\n",
     "and the prior (marginal) variance (ignoring the noise contribution)\n",
     "$$\n",
-    "V[f(\\boldsymbol x_*)] = \\alpha^2\\boldsymbol\\phi(\\boldsymbol x_*) \\boldsymbol\\phi(\\boldsymbol x_*)^\\top\n",
+    "V[f(\\boldsymbol x_*)] = \\alpha^2\\boldsymbol\\phi(\\boldsymbol x_*)^\\top \\boldsymbol\\phi(\\boldsymbol x_*)\n",
     "$$\n",
     "where $\\boldsymbol\\phi(\\cdot)$ is the feature map."
    ]


### PR DESCRIPTION
Fixes a linear algebra transpose typo in the markdown text of Section 3 (Bayesian Linear Regression). 

The formula for the prior (marginal) variance of the latent function was written as an outer product ($\alpha^2 \boldsymbol{\phi}(\boldsymbol{x}_*) \boldsymbol{\phi}(\boldsymbol{x}_*)^\top$), which yields a matrix. This PR corrects the order to an inner product ($\alpha^2 \boldsymbol{\phi}(\boldsymbol{x}_*)^\top \boldsymbol{\phi}(\boldsymbol{x}_*)$) to correctly evaluate to a scalar variance, matching the actual code implementation in the subsequent cell.